### PR TITLE
修复无法正确获得流量数据的bug

### DIFF
--- a/client.py
+++ b/client.py
@@ -221,9 +221,9 @@ class Client(object):
         else:
             s = ''.join(['inbound>>>', tag, '>>>traffic>>>'])
         if uplink:
-            s = s + '>>>uplink'
+            s = s + 'uplink'
         else:
-            s = s + '>>>downlink'
+            s = s + 'downlink'
         stub = stats_command_pb2_grpc.StatsServiceStub(self._channel)
 
         resp = stub.GetStats(


### PR DESCRIPTION
正确的格式是traffic>>>uplink
上面的代码会产生traffic>>>>>>uplink，造成流量数据永远返回None